### PR TITLE
Add tpot full

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,9 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.6.* *_cpython
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-About tpot
-==========
+About tpot-build
+================
 
 Home: https://epistasislab.github.io/tpot
 
-Package license: LGPL-3.0-or-later
+Package license: LGPL-3.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tpot-feedstock/blob/master/LICENSE.txt)
 
@@ -49,20 +49,26 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-tpot-green.svg)](https://anaconda.org/conda-forge/tpot) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot.svg)](https://anaconda.org/conda-forge/tpot) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot.svg)](https://anaconda.org/conda-forge/tpot) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot.svg)](https://anaconda.org/conda-forge/tpot) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--dask-green.svg)](https://anaconda.org/conda-forge/tpot-dask) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-dask.svg)](https://anaconda.org/conda-forge/tpot-dask) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-dask.svg)](https://anaconda.org/conda-forge/tpot-dask) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-dask.svg)](https://anaconda.org/conda-forge/tpot-dask) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--full-green.svg)](https://anaconda.org/conda-forge/tpot-full) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-full.svg)](https://anaconda.org/conda-forge/tpot-full) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-full.svg)](https://anaconda.org/conda-forge/tpot-full) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-full.svg)](https://anaconda.org/conda-forge/tpot-full) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--imblearn-green.svg)](https://anaconda.org/conda-forge/tpot-imblearn) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-imblearn.svg)](https://anaconda.org/conda-forge/tpot-imblearn) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-imblearn.svg)](https://anaconda.org/conda-forge/tpot-imblearn) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-imblearn.svg)](https://anaconda.org/conda-forge/tpot-imblearn) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--mdr-green.svg)](https://anaconda.org/conda-forge/tpot-mdr) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-mdr.svg)](https://anaconda.org/conda-forge/tpot-mdr) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-mdr.svg)](https://anaconda.org/conda-forge/tpot-mdr) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-mdr.svg)](https://anaconda.org/conda-forge/tpot-mdr) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--skrebate-green.svg)](https://anaconda.org/conda-forge/tpot-skrebate) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-skrebate.svg)](https://anaconda.org/conda-forge/tpot-skrebate) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-skrebate.svg)](https://anaconda.org/conda-forge/tpot-skrebate) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-skrebate.svg)](https://anaconda.org/conda-forge/tpot-skrebate) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-tpot--torch-green.svg)](https://anaconda.org/conda-forge/tpot-torch) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/tpot-torch.svg)](https://anaconda.org/conda-forge/tpot-torch) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/tpot-torch.svg)](https://anaconda.org/conda-forge/tpot-torch) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/tpot-torch.svg)](https://anaconda.org/conda-forge/tpot-torch) |
 
-Installing tpot
-===============
+Installing tpot-build
+=====================
 
-Installing `tpot` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `tpot-build` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `tpot` can be installed with:
+Once the `conda-forge` channel has been enabled, `tpot, tpot-dask, tpot-full, tpot-imblearn, tpot-mdr, tpot-skrebate, tpot-torch` can be installed with:
 
 ```
-conda install tpot
+conda install tpot tpot-dask tpot-full tpot-imblearn tpot-mdr tpot-skrebate tpot-torch
 ```
 
 It is possible to list all of the versions of `tpot` available on your platform with:
@@ -110,26 +116,26 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating tpot-feedstock
-=======================
+Updating tpot-build-feedstock
+=============================
 
-If you would like to improve the tpot recipe or build a new
+If you would like to improve the tpot-build recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/tpot-feedstock are
+Note that all branches in the conda-forge/tpot-build-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About tpot-build
 
 Home: https://epistasislab.github.io/tpot
 
-Package license: LGPL-3.0
+Package license: LGPL-3.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tpot-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,10 +54,14 @@ outputs:
         - pip
       imports:
         - tpot
+        - tpot.operators
+        - tpot.operators.classifiers
+        - tpot.operators.preprocessors
+        - tpot.operators.selectors
       commands:
         - pip check
-        - tpot --help
         - tpot --version
+        - tpot --help
 
   - name: tpot-skrebate
     build:
@@ -181,11 +185,11 @@ outputs:
         - tests
       commands:
         - pip check
-        - nosetests tests
+        - nosetests tests -s -v -e test_dask_matches -e test_StackingEstimator_4 -e test_sample_weight_func -e one_hot_encoder_tests -e test_score_2
 
 about:
   home: https://epistasislab.github.io/tpot
-  license: LGPL-3.0
+  license: LGPL-3.0-or-later
   license_family: GPL
   license_file: LICENSE
   summary: 'A Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming.'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,8 @@ outputs:
       host:
         - python {{ tpot_python }}
       run:
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - python {{ tpot_python }}
         - skrebate >=0.3.4
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,10 +54,6 @@ outputs:
         - pip
       imports:
         - tpot
-        - tpot.operators
-        - tpot.operators.classifiers
-        - tpot.operators.preprocessors
-        - tpot.operators.selectors
       commands:
         - pip check
         - tpot --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,9 @@
 {% set version = "0.11.7" %}
+{% set build_number = "1" %}
+{% set tpot_python = ">=3.5" %}
 
 package:
-  name: tpot
+  name: tpot-build
   version: {{ version }}
 
 source:
@@ -9,57 +11,182 @@ source:
   sha256: 64ff1845efdec3d9c70b35587f719cc0821722f27d16f542f83bf81f448e3ff1
 
 build:
-  number: 0
+  number: {{ build_number }}
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-  entry_points:
-    - tpot=tpot:main
 
 requirements:
   host:
-    - python >=3.5
-    - pip
-  run:
-    - deap >=1.2
-    - joblib >=0.13.2
-    - numpy >=1.16.3
-    - pandas >=0.24.2
-    - py-xgboost >=1.1.0
-    - python >=3.5
-    - scikit-learn >=0.22.0
-    - scipy >=1.3.1
-    - stopit >=1.1.2
-    - tqdm >=4.36.1
-    - update_checker >=0.16
+    - python {{ tpot_python }}
 
 test:
-  requires:
-    - dask >=0.18.2
-    - dask-ml >=1.0.0
-    - distributed >=1.22.1
-    - imbalanced-learn >=0.7.0
-    - nose
-    - pip
-    - python
-    - pytorch-cpu
-    - scikit-mdr >=0.4.4
-    - skrebate >=0.3.4
-  source_files:
-    - tests
-  imports:
-    - tpot
   commands:
-    - python -m pip check
-    - tpot --help
-    - tpot --version
-    - nosetests tests -s -v -e test_dask_matches -e test_StackingEstimator_4 -e test_sample_weight_func -e one_hot_encoder_tests -e test_score_2
+    - echo "the subpackages are tested"
+
+outputs:
+  - name: tpot
+
+    build:
+      number: {{ build_number }}
+      noarch: python
+      script: {{ PYTHON }} -m pip install . --no-deps -vv
+      entry_points:
+        - tpot = tpot:main
+
+    requirements:
+      host:
+        - pip
+        - python {{ tpot_python }}
+      run:
+        - deap >=1.2
+        - joblib >=0.13.2
+        - numpy >=1.16.3
+        - pandas >=0.24.2
+        - py-xgboost >=1.1.0
+        - python {{ tpot_python }}
+        - scikit-learn >=0.22.0
+        - scipy >=1.3.1
+        - stopit >=1.1.2
+        - tqdm >=4.36.1
+        - update_checker >=0.16
+
+    test:
+      requires:
+        - pip
+      imports:
+        - tpot
+      commands:
+        - pip check
+        - tpot --help
+        - tpot --version
+
+  - name: tpot-skrebate
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - skrebate >=0.3.4
+    test:
+      imports:
+        - tpot
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: tpot-mdr
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - python {{ tpot_python }}
+        - scikit-mdr >=0.4.4
+    test:
+      imports:
+        - tpot
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: tpot-dask
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - dask >=0.18.2
+        - dask-ml >=1.0.0
+        - distributed >=1.22.1
+        - python {{ tpot_python }}
+    test:
+      imports:
+        - tpot
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: tpot-torch
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - python {{ tpot_python }}
+        - pytorch
+    test:
+      imports:
+        - tpot.builtins.nn
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: tpot-imblearn
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - imbalanced-learn >=0.7.0
+        - python {{ tpot_python }}
+    test:
+      imports:
+        - tpot
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: tpot-full
+    build:
+      number: {{ build_number }}
+      noarch: python
+    requirements:
+      host:
+        - python {{ tpot_python }}
+      run:
+        - {{ pin_subpackage('tpot-dask', exact=True) }}
+        - {{ pin_subpackage('tpot-imblearn', exact=True) }}
+        - {{ pin_subpackage('tpot-mdr', exact=True) }}
+        - {{ pin_subpackage('tpot-skrebate', exact=True) }}
+        - {{ pin_subpackage('tpot-torch', exact=True) }}
+        - {{ pin_subpackage('tpot', exact=True) }}
+        - python {{ tpot_python }}
+    test:
+      imports:
+        - tpot
+      requires:
+        - nose
+        - pip
+      source_files:
+        - tests
+      commands:
+        - pip check
+        - nosetests tests
 
 about:
   home: https://epistasislab.github.io/tpot
-  license: LGPL-3.0-or-later
+  license: LGPL-3.0
   license_family: GPL
   license_file: LICENSE
-  summary: A Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming.
+  summary: 'A Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming.'
   dev_url: https://github.com/EpistasisLab/tpot
   description: |
     Consider TPOT your Data Science Assistant. TPOT is a Python Automated


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- fixes #19 

This adds `tpot-full` with the whole raft of extra dependencies, previously only used in test. Everything can _still_ be `noarch: python` (:tada:) which is awesome, but I haven't tested this on OSX/Windows in a while, so we're really hoping for the best here... but I can't in good conscience un-noarch this just to get tests (conda-forge is not continuous integration). But since this doesn't really change anything, I think it's fine, and we'll just want to run a test offline. 

Speaking of tests:  the test running has moved to `tpot-full` (since the tests fail without all the extra deps). This in fact moves the _files_ from the tests into `tpot-full`, which reduces the size of the `tpot` (:tada:). `tpot` is then only tested with the main import, and CLI entry points, and `pip check`, which would scare me, except that we're doing the full test immediately thereafter.

On the whole I think this is a pretty good solution, as you'll be able to say!

```bash
conda install -c conda-forge tpot-full
```

And get a whole _heap_ of value.

It's fairly easy to robustly make more metapackages. If desirable, we could add `tpot-dask`, `tpot-xgboost`, `tpot-skrebate`, `tpot-mdr`, and make `tpot-full` depend on all of _those_... but the only reason i could imagine wanting not-`full` is on a very constrained platform that didn't have some of the deps of `full` for some reason. Note that i can at least _solve_ this environment on OSX, while on windows... _something_ fails. I can run this down further, but would again, see the points above. 

<details>
<summary>
<code>CONDA_SUBDIR=osx-64 conda create -c conda-forge --use-local -n foo --dry-run tpot-full
</code>
</summary>
<code><pre>

  _py-xgboost-mutex  conda-forge/osx-64::_py-xgboost-mutex-2.0-cpu_0
  bokeh              conda-forge/osx-64::bokeh-1.4.0-py38_0
  ca-certificates    conda-forge/osx-64::ca-certificates-2019.11.28-hecc5488_0
  certifi            conda-forge/osx-64::certifi-2019.11.28-py38_0
  cffi               conda-forge/osx-64::cffi-1.13.2-py38h33e799b_0
  chardet            conda-forge/osx-64::chardet-3.0.4-py38_1003
  click              conda-forge/noarch::click-7.0-py_0
  cloudpickle        conda-forge/noarch::cloudpickle-1.2.2-py_1
  cryptography       conda-forge/osx-64::cryptography-2.8-py38hafa8578_1
  cycler             conda-forge/noarch::cycler-0.10.0-py_2
  cytoolz            conda-forge/osx-64::cytoolz-0.10.1-py38h0b31af3_0
  dask               conda-forge/noarch::dask-2.9.2-py_0
  dask-core          conda-forge/noarch::dask-core-2.9.2-py_0
  dask-glm           conda-forge/noarch::dask-glm-0.2.0-py_1
  dask-ml            conda-forge/noarch::dask-ml-1.2.0-py_0
  deap               conda-forge/osx-64::deap-1.3.0-py38h4f17bb1_0
  distributed        conda-forge/noarch::distributed-2.9.3-py_0
  freetype           conda-forge/osx-64::freetype-2.10.0-h24853df_1
  fsspec             conda-forge/noarch::fsspec-0.6.2-py_0
  heapdict           conda-forge/noarch::heapdict-1.0.1-py_0
  idna               conda-forge/osx-64::idna-2.8-py38_1000
  jinja2             conda-forge/noarch::jinja2-2.10.3-py_0
  joblib             conda-forge/noarch::joblib-0.14.1-py_0
  jpeg               conda-forge/osx-64::jpeg-9c-h1de35cc_1001
  kiwisolver         conda-forge/osx-64::kiwisolver-1.1.0-py38ha1b3eb9_0
  libblas            conda-forge/osx-64::libblas-3.8.0-14_openblas
  libcblas           conda-forge/osx-64::libcblas-3.8.0-14_openblas
  libcxx             conda-forge/osx-64::libcxx-9.0.1-1
  libffi             conda-forge/osx-64::libffi-3.2.1-h6de7cb9_1006
  libgfortran        conda-forge/osx-64::libgfortran-4.0.0-2
  liblapack          conda-forge/osx-64::liblapack-3.8.0-14_openblas
  libllvm8           conda-forge/osx-64::libllvm8-8.0.1-h770b8ee_0
  libopenblas        conda-forge/osx-64::libopenblas-0.3.7-h3d69b6c_7
  libpng             conda-forge/osx-64::libpng-1.6.37-h2573ce8_0
  libtiff            conda-forge/osx-64::libtiff-4.1.0-ha78913b_3
  libxgboost         conda-forge/osx-64::libxgboost-0.90-h4a8c4bd_4
  llvm-openmp        conda-forge/osx-64::llvm-openmp-9.0.1-h28b9765_1
  llvmlite           conda-forge/osx-64::llvmlite-0.31.0-py38h05045ef_0
  locket             conda-forge/noarch::locket-0.2.0-py_2
  lz4-c              conda-forge/osx-64::lz4-c-1.8.3-h6de7cb9_1001
  markupsafe         conda-forge/osx-64::markupsafe-1.1.1-py38h0b31af3_0
  matplotlib         conda-forge/osx-64::matplotlib-3.1.2-py38_1
  matplotlib-base    conda-forge/osx-64::matplotlib-base-3.1.2-py38h11da6c2_1
  msgpack-python     conda-forge/osx-64::msgpack-python-0.6.2-py38ha1b3eb9_0
  multipledispatch   conda-forge/noarch::multipledispatch-0.6.0-py_0
  ncurses            conda-forge/osx-64::ncurses-6.1-h0a44026_1002
  numba              conda-forge/osx-64::numba-0.47.0-py38h4f17bb1_0
  numpy              conda-forge/osx-64::numpy-1.17.3-py38hde6bac1_0
  olefile            conda-forge/noarch::olefile-0.46-py_0
  openssl            conda-forge/osx-64::openssl-1.1.1d-h0b31af3_0
  packaging          conda-forge/noarch::packaging-20.0-py_0
  pandas             conda-forge/osx-64::pandas-0.25.3-py38h4f17bb1_0
  partd              conda-forge/noarch::partd-1.1.0-py_0
  pillow             conda-forge/osx-64::pillow-7.0.0-py38h918e99a_0
  pip                conda-forge/osx-64::pip-19.3.1-py38_0
  psutil             conda-forge/osx-64::psutil-5.6.7-py38h0b31af3_0
  py-xgboost         conda-forge/osx-64::py-xgboost-0.90-py38_4
  pycparser          conda-forge/osx-64::pycparser-2.19-py38_1
  pyopenssl          conda-forge/osx-64::pyopenssl-19.1.0-py38_0
  pyparsing          conda-forge/noarch::pyparsing-2.4.6-py_0
  pysocks            conda-forge/osx-64::pysocks-1.7.1-py38_0
  python             conda-forge/osx-64::python-3.8.1-h5c2c468_1
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.1-py_0
  pytz               conda-forge/noarch::pytz-2019.3-py_0
  pyyaml             conda-forge/osx-64::pyyaml-5.3-py38h0b31af3_0
  readline           conda-forge/osx-64::readline-8.0-hcfe32e1_0
  requests           conda-forge/osx-64::requests-2.22.0-py38_1
  scikit-learn       conda-forge/osx-64::scikit-learn-0.22.1-py38h3dc85bc_1
  scikit-mdr         conda-forge/noarch::scikit-mdr-0.4.4-py_0
  scipy              conda-forge/osx-64::scipy-1.4.1-py38h82752d6_0
  setuptools         conda-forge/osx-64::setuptools-45.0.0-py38_1
  six                conda-forge/osx-64::six-1.14.0-py38_0
  skrebate           conda-forge/noarch::skrebate-0.6-py_0
  sortedcontainers   conda-forge/noarch::sortedcontainers-2.1.0-py_0
  sqlite             conda-forge/osx-64::sqlite-3.30.1-h93121df_0
  stopit             conda-forge/noarch::stopit-1.1.2-py_0
  tblib              conda-forge/noarch::tblib-1.6.0-py_0
  tk                 conda-forge/osx-64::tk-8.6.10-hbbe82c9_0
  toolz              conda-forge/noarch::toolz-0.10.0-py_0
  tornado            conda-forge/osx-64::tornado-6.0.3-py38h0b31af3_0
  tpot               home/weg/mc3/conda-bld/noarch::tpot-0.11.1-py_1
  tpot-full          home/weg/mc3/conda-bld/noarch::tpot-full-0.11.1-py_1
  tqdm               conda-forge/noarch::tqdm-4.41.1-py_0
  update_checker     conda-forge/noarch::update_checker-0.16-py_0
  urllib3            conda-forge/osx-64::urllib3-1.25.7-py38_0
  wheel              conda-forge/osx-64::wheel-0.33.6-py38_0
  xz                 conda-forge/osx-64::xz-5.2.4-h1de35cc_1001
  yaml               conda-forge/osx-64::yaml-0.2.2-h0b31af3_1
  zict               conda-forge/noarch::zict-1.0.0-py_0
  zlib               conda-forge/osx-64::zlib-1.2.11-h0b31af3_1006
  zstd               conda-forge/osx-64::zstd-1.4.4-he7fca8b_1
</pre></code>
</details>

 
@proinsias @raybellwaves Thoughts?