### PR TITLE
make xgboost a hard dep, remove automerge

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
 provider:
   win: azure
 conda_forge_output_validation: true
-bot:
-  automerge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 985f13758a8f2f650add5428185dcbb7fbb0ce2be11dd7f91e515f750319dedb
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -30,6 +30,7 @@ requirements:
     - stopit >=1.1.1
     - tqdm >=4.36.1
     - update_checker >=0.16
+    - py-xgboost >=0.90
 
 test:
   requires:
@@ -38,7 +39,6 @@ test:
     - distributed >=1.22.1
     - nose
     - pip
-    - py-xgboost  # [not win]
     - python
     - pytorch-cpu
     - scikit-mdr >=0.4.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,13 +24,13 @@ requirements:
     - joblib >=0.13.2
     - numpy >=1.16.3
     - pandas >=0.24.2
+    - py-xgboost >=0.90
     - python >=3.5
     - scikit-learn >=0.22.0
     - scipy >=1.3.1
     - stopit >=1.1.1
     - tqdm >=4.36.1
     - update_checker >=0.16
-    - py-xgboost >=0.90
 
 test:
   requires:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- starts to address #30
- removes automerge, as this kind of thing has already happened at least once (torch)